### PR TITLE
Update gnome-shell-tray installation info

### DIFF
--- a/source/using-applications.rst
+++ b/source/using-applications.rst
@@ -630,7 +630,7 @@ Zip-архивы, созданные штатными средствами ОС 
 Восстановить трей можно посредством установки одного из :ref:`расширений Gnome Shell <gnome-shell-extensions>`:
 
   1. `TopIcons Plus <https://extensions.gnome.org/extension/1031/topicons/>`__ (также доступно в виде пакета ``gnome-shell-extension-topicons-plus`` в репозиториях);
-  2. `AppIndicator Support <https://extensions.gnome.org/extension/615/appindicator-support/>`__.
+  2. `AppIndicator Support <https://extensions.gnome.org/extension/615/appindicator-support/>`__ (также доступно в виде пакета ``gnome-shell-extension-appindicator`` в репозиториях).
 
 .. index:: 7zip, archive, split, optical drive, dvd, p7zip
 .. _7zip-split:


### PR DESCRIPTION
Pushing `gnome-shell-extension-appindicator` in Fedora repos. Would be cool if you also did [review](https://bugzilla.redhat.com/show_bug.cgi?id=1747811) of this package. :) Until then this PR shouldn't be merged.