### PR TITLE
Небольшое исправление команды для сжатия баз данных Firefox

### DIFF
--- a/source/using-applications.rst
+++ b/source/using-applications.rst
@@ -840,7 +840,7 @@ Zip-архивы, созданные штатными средствами ОС 
 
 .. code-block:: text
 
-    find ~/.mozilla/firefox -name *.sqlite -exec sqlite3 {} VACUUM \;
+    find ~/.mozilla/firefox -name "*.sqlite" -exec sqlite3 {} VACUUM \;
 
 Это действие абсолютно безопасно, т.к. физически удаляет лишь те данные, которые в них были помечены в качестве удалённых.
 


### PR DESCRIPTION
Подробно опишите какие изменения в проект вносит данный pull request:
Этот PR "подправляет" команду для сжатия баз данных Firefox (теперь не будет ошибки `zsh: no matches found: *.sqlite` в zsh). Работоспособность проверена и под bash, ничего не сломалось.
