### PR TITLE
Fix visibility of new search widget

### DIFF
--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,9 +1,14 @@
 div.sphinxsidebar #searchbox input[type="submit"]
 {
     visibility: hidden;
+    float: none;
 }
 
 div.sphinxsidebar #searchbox input[type="text"] 
 {
     width: 100%;
+}
+div.sphinxsidebar #searchbox form.search
+{
+    overflow: visible;
 }


### PR DESCRIPTION
Подправлены стилевые правила для корректного отображения всплывающего виджета поиска.
Были перезаписаны правла, обрезающие видимость содержимого выходящего за рамки блока формы поиска

