### PR TITLE
Prohibit ICMP with `--add..` instead

### DIFF
--- a/source/networking.rst
+++ b/source/networking.rst
@@ -222,7 +222,7 @@ PPTP
 
 .. code-block:: text
 
-    sudo firewall-cmd --zone=public --remove-icmp-block={echo-request,echo-reply,timestamp-reply,timestamp-request} --permanent
+    sudo firewall-cmd --zone=public --add-icmp-block={echo-request,echo-reply,timestamp-reply,timestamp-request} --permanent
 
 Применим новые правила:
 


### PR DESCRIPTION
Согласно https://man.archlinux.org/man/firewall-cmd.1: "Add an ICMP block for icmptype".

